### PR TITLE
Dynamic translations for food and animal cards

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,8 @@ import * as R from 'ramda';
 import { animalTranslations, foodTranslations } from './translations';
 import { CardContainer, CardHeader, CardContent } from './App.styled';
 
+// TYPE: PropsT = {food: string, translate: (string, string) => string}
+// TYPE: PropsT => ReactComponent
 const FoodCard = ({
   food,
   translate,
@@ -15,6 +17,8 @@ const FoodCard = ({
   </CardContainer>
 );
 
+// TYPE: PropsT = {animal: string, translate: (string, string) => string}
+// TYPE: PropsT => ReactComponent
 const AnimalCard = ({
   animal,
   translate,
@@ -26,30 +30,56 @@ const AnimalCard = ({
   </CardContainer>
 );
 
-// FIXME: Add your code here
-const createTranslate = ...
+// TYPE: Translations => string => string => string => string
+const translateItem = R.curry(
+  (translations, language, detail, item) =>
+    translations[item][detail][language]
+);
 
+// TYPE: Translations => ReactComponent => string => propsObject => ReactComponent
+const createTranslate = R.curry(
+  (translations, Card, language, props) => (
+    <Card
+      translate={translateItem(translations, language)}
+      {...props}
+    />
+  )
+);
+
+// TYPE: (ReactComponent, string) => ReactComponent
 const translateAnimal = createTranslate(animalTranslations);
+
+// TYPE: (ReactComponent, string) => ReactComponent
 const translateFood = createTranslate(foodTranslations);
 
 class App extends Component {
   constructor() {
     super();
+    this.state = {language: "en"};
   }
 
   render() {
+    // TYPE: ReactComponent
     const TranslatedAnimalCard = translateAnimal(AnimalCard, this.state.language);
+
+    // TYPE: ReactComponent
     const TranslatedFoodCard = translateFood(FoodCard, this.state.language);
 
     const animals = ['tiger', 'lion', 'hippo', 'platypus'];
     const foods = ['cake', 'pizza', 'hotdog', 'pancake'];
 
+    // TYPE: [ReactComponent]
     const TranslatedAnimalCards = animals.map(a => <TranslatedAnimalCard animal={a} />);
+
+    // TYPE: [ReactComponent]
     const TranslatedFoodCards = foods.map(f => <TranslatedFoodCard food={f} />);
+
+    // TYPE: Event => undefined
+    const changeLanguage = event => this.setState({language: event.target.value});
 
     return (
       <div>
-        <select value={this.state.language} onChange={/* FIXME: add your code here */}>
+        <select value={this.state.language} onChange={ changeLanguage.bind(this) }>
           <option value="en">English</option>
           <option value="es">Español</option>
           <option value="ru">русский</option>

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,7 @@ import { animalTranslations, foodTranslations } from './translations';
 import { CardContainer, CardHeader, CardContent } from './App.styled';
 
 // TYPE: PropsT = {food: string, translate: (string, string) => string}
-// TYPE: PropsT => ReactComponent
+// TYPE: PropsT => ReactElement
 const FoodCard = ({
   food,
   translate,
@@ -18,7 +18,7 @@ const FoodCard = ({
 );
 
 // TYPE: PropsT = {animal: string, translate: (string, string) => string}
-// TYPE: PropsT => ReactComponent
+// TYPE: PropsT => ReactElement
 const AnimalCard = ({
   animal,
   translate,
@@ -30,13 +30,16 @@ const AnimalCard = ({
   </CardContainer>
 );
 
+// Assume Translations is the union type of Animal and Food
+// translation JSON in translations.js
+// for the following two type annotations
 // TYPE: Translations => string => string => string => string
 const translateItem = R.curry(
   (translations, language, detail, item) =>
     translations[item][detail][language]
 );
 
-// TYPE: Translations => ReactComponent => string => propsObject => ReactComponent
+// TYPE: Translations => ReactComponent => string => ReactComponent
 const createTranslate = R.curry(
   (translations, Card, language, props) => (
     <Card
@@ -68,10 +71,10 @@ class App extends Component {
     const animals = ['tiger', 'lion', 'hippo', 'platypus'];
     const foods = ['cake', 'pizza', 'hotdog', 'pancake'];
 
-    // TYPE: [ReactComponent]
+    // TYPE: [ReactElement]
     const TranslatedAnimalCards = animals.map(a => <TranslatedAnimalCard animal={a} />);
 
-    // TYPE: [ReactComponent]
+    // TYPE: [ReactElement]
     const TranslatedFoodCards = foods.map(f => <TranslatedFoodCard food={f} />);
 
     // TYPE: Event => undefined


### PR DESCRIPTION
## Dynamic translations for food and animal cards
#### changelog:
- HOC for merging translate function into Card props
- curryable HOC creator: `translations => HOCTranslatedCard`
- language switching utilizing component state
- loose type annotations for newly filled in functions

#### notes:
Currently using R.curry instead of es6 arrow function currying.
Could rollback to native implementation if it's decided we don't
want Rambda as a dependency anymore.